### PR TITLE
fix reference before assignment error

### DIFF
--- a/protongdb.py
+++ b/protongdb.py
@@ -136,6 +136,7 @@ def main(args=None):
         for x in range(0, len(app_infos)):
             description, working_dir, launch_executable, beta_key, app_config_args = app_infos[x]
             beta_key = None
+            beta_str = ""
             if beta_key:
                 beta_str = f" | Beta: {beta_key} |"
             print(f"[{x}] {description} ({launch_executable}{list_to_space_str_prefix(app_config_args, ' ')}){beta_str}")


### PR DESCRIPTION
Fixes
```
Traceback (most recent call last):
  File "./protongdb-master/protongdb.py", line 226, in <module>
    main()
  File "./protongdb-master/protongdb.py", line 141, in main
    print(f"[{x}] {description} ({launch_executable}{list_to_space_str_prefix(app_config_args, ' ')}){beta_str}")
UnboundLocalError: local variable 'beta_str' referenced before assignment
```